### PR TITLE
add pkg-config support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,3 +25,13 @@ install(
 if(BUILD_TESTING)
   add_subdirectory(tests)
 endif()
+
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/liberror.pc.in
+  ${CMAKE_CURRENT_BINARY_DIR}/liberror.pc
+@ONLY)
+
+install(
+  FILES ${CMAKE_CURRENT_BINARY_DIR}/liberror.pc
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+)

--- a/liberror.pc.in
+++ b/liberror.pc.in
@@ -1,0 +1,12 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/include
+
+Name: liberror
+Description: A small library for rendering error messages.
+Requires: common
+Version: 20170708
+Libs: -L${libdir} -lerror
+Cflags: -I${includedir}
+


### PR DESCRIPTION
One classic way to detect and to obtain required parameters at build time requirements, to use a library, is through pkg-config.
This approach is Linux and msys2 compatible.
This PR add a pc.in file filled with prefix and all required informations, this one is installed in ${CMAKE_INSTALL_LIBDIR}/pkgconfig